### PR TITLE
Fixes a bug with parameter names on mocks.

### DIFF
--- a/src/Mock.php
+++ b/src/Mock.php
@@ -64,6 +64,6 @@ final class Mock
     public function __call(string $method, array $arguments): mixed
     {
         /* @phpstan-ignore-next-line */
-        return $this->mock->{$method}($arguments);
+        return $this->mock->{$method}(...$arguments);
     }
 }

--- a/tests/Mock.php
+++ b/tests/Mock.php
@@ -28,5 +28,16 @@ it('allows access to the underlying mockery mock', function () {
     $mock = mock(Http::class);
 
     expect($mock->expect())->toBeInstanceOf(MockInterface::class);
-    expect($mock->shouldReceive())->toBeInstanceOf(CompositeExpectation::class);
+    expect($mock->shouldReceive('get'))->toBeInstanceOf(CompositeExpectation::class);
+});
+
+it('passes the arguments to the underlying mock correctly', function () {
+    $mock = mock(Http::class);
+
+    $mock->shouldReceive('get')
+        ->atLeast()
+        ->once()
+        ->andReturn('foo');
+
+    expect($mock->get())->toBe('foo');
 });


### PR DESCRIPTION
Howdy 👋🏼

Previously, arguments in the magic `__call` method were being passed through as the captured array rather than varadically being forwarded, which was causing long-form expectations to fail. This PR fixes the issue and adds a regression test.