### PR TITLE
Allows mocks to inherit public methods from other objects

### DIFF
--- a/src/Mock.php
+++ b/src/Mock.php
@@ -64,6 +64,6 @@ final class Mock
     public function __call(string $method, array $arguments): mixed
     {
         /* @phpstan-ignore-next-line */
-        return $this->mock->{$method}($arguments);
+        return $this->mock->{$method}(...$arguments);
     }
 }

--- a/tests/Mock.php
+++ b/tests/Mock.php
@@ -8,6 +8,19 @@ interface Http
     public function get(): string;
 }
 
+class TestMock implements Http
+{
+    public function post($data): mixed
+    {
+        return $data;
+    }
+
+    public function get(): string
+    {
+        return 'foo';
+    }
+}
+
 it('can mock methods', function () {
     $mock = mock(Http::class)->expect(
         get: fn () => 'foo',
@@ -31,13 +44,17 @@ it('allows access to the underlying mockery mock', function () {
     expect($mock->shouldReceive('get'))->toBeInstanceOf(CompositeExpectation::class);
 });
 
-it('passes the arguments to the underlying mock correctly', function () {
-    $mock = mock(Http::class);
+it('can inherit calls from a class', function () {
+    $mock = mock(Http::class)->inherit(new TestMock());
 
-    $mock->shouldReceive('get')
-        ->atLeast()
-        ->once()
-        ->andReturn('foo');
-
+    expect($mock->post('foo'))->toBe('foo');
     expect($mock->get())->toBe('foo');
+});
+
+it('can override inherited calls', function () {
+    $mock = mock(Http::class)
+        ->inherit(new TestMock())
+        ->expect(get: fn() => 'bar');
+
+    expect($mock->get())->toBe('bar');
 });

--- a/tests/Mock.php
+++ b/tests/Mock.php
@@ -52,9 +52,9 @@ it('can inherit calls from a class', function () {
 });
 
 it('can override inherited calls', function () {
-    $mock = mock(Http::class)
+    $mock = mock(TestMock::class)
         ->inherit(new TestMock())
-        ->expect(get: fn() => 'bar');
+        ->expect(get: fn () => 'bar');
 
     expect($mock->get())->toBe('bar');
 });

--- a/tests/Mock.php
+++ b/tests/Mock.php
@@ -28,5 +28,16 @@ it('allows access to the underlying mockery mock', function () {
     $mock = mock(Http::class);
 
     expect($mock->expect())->toBeInstanceOf(MockInterface::class);
-    expect($mock->shouldReceive())->toBeInstanceOf(CompositeExpectation::class);
+    expect($mock->shouldReceive('get'))->toBeInstanceOf(CompositeExpectation::class);
+});
+
+it('passes the arguments to the underlying mock correctly', function () {
+    $mock = mock(Http::class);
+
+    $mock->shouldReceive('get')
+        ->atLeast()
+        ->once()
+        ->andReturn('foo');
+
+    expect($mock->get())->toBe('foo');
 });


### PR DESCRIPTION
Hey!

So, this is one that I find super useful but completely understand if you're not a fan. Usually in larger projects, a mocked interface might have multiple public methods that get called in a feature test. You're only interested in testing one of those methods, but still need to provide a fallback for the other methods.

You might think "that's a partial mock", but I beg to differ because the partial mock might still be doing too much and may still require you to mock the methods/dependencies out.

This PR adds the idea of *inheriting* public class methods for a mock. You pass it a class, and it will look up its public methods and defer to those if no hard expectation has been set. 

## Example

First of all, we create an object. It doesn't have to implement anything, but it can if we want to force it to have all of the methods of the interface we're testing.

```php
class BackupClass implements SomeInterface {
    public function get() {
        return 'Hello World';
    }

    public function post() {
        return 'Foo Bar';
    }
}
```

Now we write our test. We can call methods without using `expect`, and it will use the method call from the inherited class instead.

```php
$mock = mock(Http::class)->inherit(new BackupClass);

expect($mock->post('get'))->toBe('Hello World');
```

However, if we use an `extend` call, it will opt for our overridden version:

```php
$mock = mock(Http::class)
    ->inherit(new BackupClass)
    ->extend(post: fn() => "Hey Nuno!");

expect($mock->post('get'))->toBe('Hey Nuno!');
```

This gets even more powerful in feature tests, where other methods on the interface might be being called, but you're not interested in testing them at this moment.

```php
$mock = mock(Http::class)
    ->inherit(new BackupClass)
    ->extend(post: fn() => "Hey Nuno!");

$this->swap(Http:class, $mock);

expect(someFeatureThatCallsGetButReturnsPost())->toBe('Hey Nuno!');
```

This implementation also allows you to provide multiple inherited classes, so you could mix and match methods together based on the use case required for the given test.

Let me know what you think. Hope you're having a good week!
