### PR TITLE
Update minimum php version to 7.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     ],
     "license": "MIT",
     "require": {
-        "php": "^8.0",
+        "php": "^7.3 || ^8.0",
         "mockery/mockery": "^1.4",
         "pestphp/pest": "^1.0",
         "pestphp/pest-plugin": "^1.0"


### PR DESCRIPTION
Pest's minimum PHP version is 7.3 and this plugin is not installable on PHP 7.4.