### PR TITLE
Fix pest `mock` function without overwriting mockery's global helpers

### DIFF
--- a/src/Autoload.php
+++ b/src/Autoload.php
@@ -2,19 +2,17 @@
 
 declare(strict_types=1);
 
-use Pest\Mock\Mock;
+namespace Pest\Mock;
 
-if (! function_exists('mock')) {
-    /**
-     * Creates a new mock with the given class or object.
-     *
-     * @template TObject as object
-     *
-     * @param  class-string<TObject>|TObject  $object
-     * @return Mock<TObject>
-     */
-    function mock(object|string $object): Mock
-    {
-        return new Mock($object);
-    }
+/**
+ * Creates a new mock with the given class or object.
+ *
+ * @template TObject as object
+ *
+ * @param  class-string<TObject>|TObject  $object
+ * @return Mock<TObject>
+ */
+function mock(object|string $object): Mock
+{
+    return new Mock($object);
 }

--- a/tests/Mock.php
+++ b/tests/Mock.php
@@ -2,6 +2,7 @@
 
 use Mockery\CompositeExpectation;
 use Mockery\MockInterface;
+use function Pest\Mock\mock;
 
 interface Http
 {


### PR DESCRIPTION
This pull request proposes to make the following changes:

- Move `mock` function into `Pest\Mock` namespace
- Update test

Resolve https://github.com/pestphp/pest/issues/831

To use Pest's `mock` function, add `use function Pest\Mock\mock;` at the top of the test file to import the function.
